### PR TITLE
removed the purchase modal from the event modal, added purchase options

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -28,7 +28,7 @@ class PagesController < ApplicationController
   def dashboard
     @bookmarks = current_user.bookmarks.includes(event: :chatroom)
     @itinerary = current_user.itineraries
-    @first_chatroom =  @bookmarks.find { |bookmark| bookmark.event.chatroom.present? && bookmark.user }&.event&.chatroom.id
+    # @first_chatroom =  @bookmarks.find { |bookmark| bookmark.event.chatroom.present? && bookmark.user }&.event&.chatroom.id
     # raise
     @bookmarks.each do |bookmark|
       update_status_with_time(bookmark)

--- a/app/views/shared/_all_events.html.erb
+++ b/app/views/shared/_all_events.html.erb
@@ -40,29 +40,30 @@
                           <% end %>
                         </div>
                         <div class="row">
-                          <div class="col-sm-9">
+                          <div class="col-sm-12">
                             <p><b>Date: </b><%= event.start_time %></p>
                             <p><b>Location: </b><%= event.address %></p>
+                            <p><%= event.description %></p>
                           </div>
-
-                            <div class="col-sm-3" >
-                              <!-- Need to add the if statement to display only if a user is currently signed in here... -->
-                              <%= link_to "Bookmark me", event_bookmarks_path(event), data: { turbo_method: :post, turbo_confirm: "Are you interested?" }, class: "btn btn-dark" %>
-                            </div>
                         </div>
-
-                        <div class="row">
-                            <div class="col-sm-12">
-                              <p><%= event.description %></p>
-                            </div>
+                      </div><div class="modal-footer text-center">
+                        <div class="row align-items-start">
+                          <div class="row">
+                            <p><b><em>Click on one of the links below to purchase your tickets.</em></b></p>
+                          </div>
+                          <div class="row">
+                            <% if event.ticket_purchase.present? %>
+                              <% ticket_purchase_json = JSON.parse(event.ticket_purchase) %>
+                              <% ticket_purchase_json.each do |info| %>
+                                <div class="p-2"><a class="btn btn-dark" href="<%= info["link"] %>" target="_blank"><%= info["source"] %></a></div>
+                              <% end %>
+                            <% end %>
+                          </div>
                         </div>
-                      </div>
-                      <div class="modal-footer">
                       </div>
                   </div>
                 </div>
               </div>
-
 
                   <div class="card-address"><%= event.address %></div>
                   <div class="card-date"><%= event.start_time.strftime('%d %b') %> - <%= event.end_time.strftime('%d %b') %></div>
@@ -80,6 +81,38 @@
                         <%= link_to "Bookmark me", event_bookmarks_path(event), data: { turbo_method: :post, turbo_confirm: "Are you interested?" }, class: "btn btn-dark" %>
                       <% end %>
                     <% end %>
+                  </div>
+                  <div>
+                    <% if current_user.present? %>
+                      <button type="button" class="btn btn-dark" data-bs-toggle="modal" data-bs-target="#purchase<%= event.id %>">Purchase</button>
+                    <% end %>
+
+                            <!-- Purchase Modal -->
+                              <div class="modal fade" id="purchase<%= event.id %>" data-bs-backdrop="static" data-bs-keyboard="false" tabindex="-1" aria-labelledby="purchase" aria-hidden="true">
+                                <div class="modal-dialog">
+                                  <div class="modal-content">
+                                    <div class="modal-header">
+                                      <h2>Where would you like to purchase?</h2>
+                                    </div>
+                                    <div class="modal-body purchase">
+                                      <div class="d-flex flex-column align-items-center">
+                                        <% if event.ticket_purchase.present? %>
+                                          <% ticket_purchase_json = JSON.parse(event.ticket_purchase) %>
+                                          <% ticket_purchase_json.each do |info| %>
+                                            <div class="p-2"><a class="btn btn-dark" href="<%= info["link"] %>" target="_blank"><%= info["source"] %></a></div>
+                                          <% end %>
+                                        <% else %>
+                                          <p>No ticket purchase information available.</p>
+                                        <% end %>
+                                      </div>
+                                    </div>
+                                    <div class="modal-footer">
+                                      <button type="reset" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
+                                    </div>
+                                  </div>
+                                </div>
+                              </div>
+
                   </div>
                   <div>
                     <% if @itinerary.present? %>


### PR DESCRIPTION
- Removed the purchase modal from the event modal, added the purchase modal options in the event modal
- We decided that we would leave the action buttons of the card outside of the event modal, since we were having too many issues with a modal inside of a modal 
<img width="715" alt="Screenshot 2566-12-04 at 17 09 30" src="https://github.com/berulds/eventseeker/assets/106658187/5a37a349-fd4d-4c81-9359-07e6d7b8bb04">
