### PR TITLE
Event Cards

### DIFF
--- a/app/assets/stylesheets/components/_chatroom.scss
+++ b/app/assets/stylesheets/components/_chatroom.scss
@@ -5,12 +5,17 @@
 }
 
 .chat-container {
+  background-color: #f1f1f1;
   padding: 17px;
   border-radius: 8px;
+  overflow-y: scroll;
+  height: 100%;
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
+  max-width: 50%;
 }
 
 .chat-card {
-  width: 500px;
+  width: 700px;
   height: 100px;
   background-color: #ffffff;
   border-radius: 5px;
@@ -19,29 +24,41 @@
   display: flex;
   flex-direction: column;
   justify-content: flex-start;
-}
 
-.chat-card img {
-  width: 100px;
-  height: 100px;
-  object-fit: cover;
+  img {
+    width: 100px;
+    height: 100px;
+    object-fit: cover;
+  }
 }
 
 .chat-card-content {
   padding: 16px;
+  width: 100%;
 }
 
 .chat-card-title {
   font-size: 16px;
   font-weight: bold;
   margin-bottom: 8px;
-  text-align: left;
-  width: 275px;
+  width: 100%;
   overflow: hidden;
+  max-height: 25px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
 
   a {
     text-decoration: none;
     color: black;
+  }
+
+  .fa-comments:hover::before {
+    content: "Enter Chat";
+    font-size: 16px;
+    color: black;
+    padding: 5px;
+    border-radius: 5px;
   }
 }
 
@@ -51,11 +68,7 @@
   font-weight: 510;
   margin-bottom: 8px;
   justify-content: flex-end;
-}
-
-.chat-card:hover {
-  box-shadow: 0 8px 16px rgba(0, 0, 0, 0.5);
-  transform: scale(1.1);
+  margin-left: 13px;
 }
 
 .chatroom-details {

--- a/app/assets/stylesheets/itineraries/_show.scss
+++ b/app/assets/stylesheets/itineraries/_show.scss
@@ -13,7 +13,7 @@
   height: 100%;
   box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
   z-index: 1;
-  width: 544px;
+  width: 580px;
 }
 
 .show-card {

--- a/app/assets/stylesheets/pages/_home.scss
+++ b/app/assets/stylesheets/pages/_home.scss
@@ -165,37 +165,42 @@ body {
   display: flex;
   flex-direction: column;
   justify-content: space-between;
-}
 
-.card img {
-  width: 100%;
-  height: 200px;
-  object-fit: cover;
+  img {
+    width: 100%;
+    min-height: 200px;
+    object-fit: cover;
+  }
 }
 
 .card-content {
   padding: 16px;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  justify-content: start;
 }
 
 .card-title {
-  font-size: 18px;
+  font-size: 20px;
   font-weight: bold;
   margin-bottom: 8px;
-}
+  display: flex;
+  justify-content: center;
+  height: 80px;
 
-.card-address {
-  font-size: 14px;
-  color: #646464;
-  margin-bottom: 7px;
+  button {
+    width: 300px;
+  }
 }
 
 .card-description {
   font-size: 13px;
   margin-bottom: 8px;
-  overflow: hidden;
   display: -webkit-box;
   -webkit-line-clamp: 3;
   -webkit-box-orient: vertical;
+  overflow: hidden;
 }
 
 .card-date {
@@ -205,17 +210,51 @@ body {
   margin-bottom: 8px;
 }
 
-#event-card-buttons {
-  gap: 15px;
-}
-
-
 .card-actions {
-  bottom: 8px;
   width: 100%;
-  text-align: center;
-  align-items: center;
-  margin-bottom: 20px;
+  display: flex;
+  justify-content: end;
+  padding: 16px;
+
+  .fa-bookmark:hover::before {
+    content: "Bookmark Event";
+    font-size: 16px;
+    color: black;
+    padding: 5px;
+    border-radius: 5px;
+  }
+
+  .fa-cart-shopping:hover::before {
+    content: "Purchase Tickets";
+    font-size: 16px;
+    color: black;
+    padding: 5px;
+    border-radius: 5px;
+  }
+
+  .fa-x:hover::before {
+    content: "Remove Bookmark";
+    font-size: 16px;
+    color: black;
+    padding: 5px;
+    border-radius: 5px;
+  }
+
+  .fa-plus:hover::before {
+    content: "Add To Itinerary";
+    font-size: 16px;
+    color: black;
+    padding: 5px;
+    border-radius: 5px;
+  }
+
+  .fa-comments:hover::before {
+    content: "Join Event Chat";
+    font-size: 16px;
+    color: black;
+    padding: 5px;
+    border-radius: 5px;
+  }
 }
 
 .see-more-card {
@@ -239,4 +278,15 @@ main {
 
 .footer-about {
   position: relative;
+}
+
+.modal {
+  top: 56px;
+  height: 80%;
+
+  img {
+    width: 100%;
+    max-height: 400px;
+    object-fit: cover;
+  }
 }

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -28,7 +28,7 @@ class PagesController < ApplicationController
   def dashboard
     @bookmarks = current_user.bookmarks.includes(event: :chatroom)
     @itinerary = current_user.itineraries
-    @first_chatroom =  @bookmarks.find { |bookmark| bookmark.event.chatroom.present? && bookmark.user }&.event&.chatroom.id
+    @first_chatroom = @bookmarks.find { |bookmark| bookmark.event&.chatroom.present? && bookmark.user }&.event&.chatroom&.id
     # raise
     @bookmarks.each do |bookmark|
       update_status_with_time(bookmark)

--- a/app/views/chatrooms/show.html.erb
+++ b/app/views/chatrooms/show.html.erb
@@ -10,19 +10,76 @@
               <%= link_to "Back to dashboard", pages_dashboard_path %>
             </div>
           </div>
-          <% @bookmarks.sort_by { |bookmark| bookmark.event.start_time }.each do |bookmark| %>
-            <% if bookmark.event.chatroom.present? && bookmark.user == current_user %>
-              <div class="chat-card d-flex flex-row mb-3 mt-3">
-                <% if bookmark.event.photo.present? %>
-                  <img src=<%= cl_image_path(bookmark.event.photo.key, alt: "event image") %> alt="Event Image">
-                <% else %>
-                  <img src="path_to_default_image" alt="Default Event Image">
-                <% end %>
-                <div class="chat-card-content d-flex">
-                  <div class="chat-card-title"><%= link_to "Join the #{bookmark.event.name} channel", chatroom_path(bookmark.event.chatroom.id) %></div>
-                  <div class="chat-card-date"><%= bookmark.event.start_time.strftime('%a %b %e') %></div>
+          <% @bookmarks.select { |bookmark| bookmark.event.chatroom.present? && bookmark.user == current_user }.sort_by { |bookmark| bookmark.event.start_time }.group_by { |bookmark| bookmark.event.start_time.to_date }.sort.each do |date, grouped_bookmarks| %>
+            <div class="date-header">
+              <h3><%= date.strftime(('%a %b %e')) %></h3>
+            </div>
+            <% grouped_bookmarks.each do |bookmark| %>
+            <div class="chat-card d-flex flex-row mb-3 mt-3">
+              <% if bookmark.event.photo.present? %>
+                <img src=<%= cl_image_path(bookmark.event.photo.key, alt: "event image") %> alt="Event Image">
+              <% else %>
+                <img src="path_to_default_image" alt="Default Event Image">
+              <% end %>
+              <div class="chat-card-content">
+                <div class="chat-card-title">
+                  <button type="button" class="btn" data-bs-toggle="modal" data-bs-target="#exampleModal<%= bookmark.event.id %>"><%= bookmark.event.name %></button>
+                  <%= link_to chatroom_path(bookmark.event.chatroom.id) do %>
+                    <i class="fa-solid fa-comments" style="color: #000000;"></i>
+                  <% end %>
+                </div>
+                <div class="chat-card-date"><%= bookmark.event.start_time.strftime('%a %b %e') %></div>
+              </div>
+            </div>
+
+              <div class="modal fade" id="exampleModal<%= bookmark.event.id %>" tabindex="-1" aria-labelledby="exampleModalLabel" aria-hidden="true">
+                <div class="modal-dialog modal-lg">
+                  <div class="modal-content">
+                    <div class="modal-header">
+                      <h1 class="modal-title fs-5" id="exampleModalLabel"><%= bookmark.event.name %></h1>
+                      <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                    </div>
+                    <div class="modal-body">
+                      <div class="row">
+                        <% if bookmark.event.photo.present? %>
+                          <div class="col-sm-12 mb-3">
+                            <img src=<%= cl_image_path(bookmark.event.photo.key, alt: "event image") %> alt="Event Image">
+                          </div>
+                        <% else %>
+                          <div class="col-sm-12 mb-3">
+                            <img src="path_to_default_image" alt="Default Event Image">
+                          </div>
+                        <% end %>
+                      </div>
+                      <div class="row">
+                        <div class="col-sm-12">
+                          <p><b>Date: </b><%= bookmark.event.start_time %></p>
+                          <p><b>Location: </b><%= bookmark.event.address %></p>
+                          <p><%= bookmark.event.description %></p>
+                        </div>
+                      </div>
+                    </div>
+                    <% if bookmark.event.ticket_purchase.present? %>
+                      <div class="modal-footer text-center">
+                        <div class="row align-items-start">
+                          <div class="row">
+                            <p><b><em>Click on one of the links below to purchase your tickets.</em></b></p>
+                          </div>
+                          <div class="row">
+                            <% if bookmark.event.ticket_purchase.present? %>
+                              <% ticket_purchase_json = JSON.parse(bookmark.event.ticket_purchase) %>
+                              <% ticket_purchase_json.each do |info| %>
+                                <div class="p-2"><a class="btn" href="<%= info["link"] %>" target="_blank"><%= info["source"] %></a></div>
+                              <% end %>
+                            <% end %>
+                          </div>
+                        </div>
+                      </div>
+                    <% end %>
+                  </div>
                 </div>
               </div>
+
             <% end %>
           <% end %>
         </div>

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -1,4 +1,4 @@
-<div class="container">
+<div class="container d-flex">
   <div class="justify-content-center">
     <div class="d-flex">
 
@@ -19,7 +19,6 @@
                 </div>
 
                 <!-- Event Modal -->
-
                 <div class="modal fade" id="exampleModal<%= event.id %>" tabindex="-1" aria-labelledby="exampleModalLabel" aria-hidden="true">
                   <div class="modal-dialog modal-lg">
                     <div class="modal-content">
@@ -57,7 +56,7 @@
                               <% if event.ticket_purchase.present? %>
                                 <% ticket_purchase_json = JSON.parse(event.ticket_purchase) %>
                                 <% ticket_purchase_json.each do |info| %>
-                                  <div class="p-2"><a class="btn btn-dark" href="<%= info["link"] %>" target="_blank"><%= info["source"] %></a></div>
+                                  <div class="p-2"><a class="btn" href="<%= info["link"] %>" target="_blank"><%= info["source"] %></a></div>
                                 <% end %>
                               <% end %>
                             </div>
@@ -68,26 +67,27 @@
                   </div>
                 </div>
 
-                <div class="card-address"><%= event.address %></div>
                 <div class="card-date"><%= event.start_time.strftime('%a %b %e') %> - <%= event.end_time.strftime('%a %b %e') %></div>
                 <div class="card-description"><%= event.description %></div>
               </div>
-              <div class="card-actions d-flex justify-content-center" id="event-card-buttons">
+              <div class="card-actions" id="event-card-buttons">
                 <div>
                   <% if current_user.present? == false %>
-                    <%= link_to "Login/Sign Up to save", new_user_session_path,class: "btn btn-dark" %>
+                    <%= link_to "Login/Sign Up to continue", new_user_session_path,class: "btn" %>
                   <% end %>
                 </div>
                 <div>
                   <% if current_user.present? %>
                     <% unless current_user.bookmarks.exists?(event_id: event.id) %>
-                      <%= link_to "Bookmark me", event_bookmarks_path(event), data: { turbo_method: :post, turbo_confirm: "Are you interested?" }, class: "btn btn-dark" %>
+                      <%= link_to event_bookmarks_path(event), data: { turbo_method: :post, turbo_confirm: "Are you interested?" }, class: "btn" do %>
+                        <i class="fa-solid fa-bookmark" style="color: #000000;"></i>
+                      <% end %>
                     <% end %>
                   <% end %>
                 </div>
                 <div>
                   <% if current_user.present? %>
-                    <button type="button" class="btn btn-dark" data-bs-toggle="modal" data-bs-target="#purchase<%= event.id %>">Purchase</button>
+                    <button type="button" class="btn" data-bs-toggle="modal" data-bs-target="#purchase<%= event.id %>"><i class="fa-solid fa-cart-shopping" style="color: #000000;"></i></button>
                   <% end %>
                           <!-- Purchase Modal -->
                   <div class="modal fade" id="purchase<%= event.id %>" data-bs-backdrop="static" data-bs-keyboard="false" tabindex="-1" aria-labelledby="purchase" aria-hidden="true">
@@ -101,15 +101,15 @@
                             <% if event.ticket_purchase.present? %>
                               <% ticket_purchase_json = JSON.parse(event.ticket_purchase) %>
                               <% ticket_purchase_json.each do |info| %>
-                                <div class="p-2"><a class="btn btn-dark" href="<%= info["link"] %>" target="_blank"><%= info["source"] %></a></div>
+                                <div class="p-2"><a class="btn" href="<%= info["link"] %>" target="_blank"><%= info["source"] %></a></div>
                               <% end %>
                             <% else %>
-                              <p>No ticket purchase information available.</p>
+                              <p><i class="fa-solid fa-cart-shopping" style="color: #000000;"></i> No ticket purchase information available.</p>
                             <% end %>
                           </div>
                         </div>
                         <div class="modal-footer">
-                          <button type="reset" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
+                          <button type="reset" class="btn-close" data-bs-dismiss="modal"></button>
                         </div>
                       </div>
                     </div>
@@ -117,10 +117,12 @@
                 </div>
                 <div>
                   <% if @itinerary.present? %>
-                    <%= link_to "Add", itinerary_itinerary_events_path(@itinerary, event_id: event.id), class: "btn btn-dark", data: { turbo_method: :post } %>
+                    <%= link_to itinerary_itinerary_events_path(@itinerary, event_id: event.id), class: "btn", data: { turbo_method: :post } do %>
+                      <i class="fa-solid fa-plus" style="color: #000000;"></i>
+                    <% end %>
                   <% else %>
                     <% if current_user.present? %>
-                      <button type="button" class="btn btn-dark" data-bs-toggle="modal" data-bs-target="#addToItinerary-<%= event.id %>">Add to an itinerary</button>
+                      <button type="button" class="btn" data-bs-toggle="modal" data-bs-target="#addToItinerary-<%= event.id %>"><i class="fa-solid fa-plus" style="color: #000000;"></i></button>
                       <div class="modal fade" id="addToItinerary-<%= event.id %>" data-bs-backdrop="static" data-bs-keyboard="false" tabindex="-1" aria-labelledby="addToItineraryLabel" aria-hidden="true" data-controller="add-to-itinerary">
                         <div class="modal-dialog">
                           <div class="modal-content">
@@ -137,8 +139,8 @@
                                   <% end %>
                                 </select>
                                 <div class="modal-footer">
-                                  <button type="reset" class="btn btn-dark" data-bs-dismiss="modal">Close</button>
-                                  <button type="reset" class="btn btn-dark" data-bs-toggle="modal" data-bs-target="#addToItinerary-<%= event.id %>" id="addToItineraryButton-<%= event.id %>">Add to this itinerary</button>
+                                  <button type="reset" class="btn" data-bs-toggle="modal" data-bs-target="#addToItinerary-<%= event.id %>" id="addToItineraryButton-<%= event.id %>"><i class="fa-solid fa-plus" style="color: #000000;"></i></button>
+                                  <button type="reset" class="btn-close" data-bs-dismiss="modal"></button>
                                 </div>
                               </form>
                             </div>

--- a/app/views/pages/dashboard.html.erb
+++ b/app/views/pages/dashboard.html.erb
@@ -11,7 +11,7 @@
             <% end %>
           </div>
           <div class="col-md-8">
-            <h5 class="card-title"> <%= @current_user.username %></h5>
+            <h5 class="card-title"> <%= @current_user.username.capitalize %></h5>
             <p class="card-text">Welcome back <%= @current_user.username %>! Here's what's happening.</p>
             <p class="card-text"><%= Date.today.strftime('%a %b %e') %></p>
           </div>
@@ -19,7 +19,7 @@
             <div class="p-2"><%= link_to "Create Event", new_event_path, class: "btn btn-success dash-link" %></div>
             <div class="p-2"><%= link_to "Create Itinerary", new_itinerary_path, class: "btn btn-success dash-link" %></div>
               <% if @first_chatroom %>
-              <div class="p-2"> <%= link_to "My chatrooms", chatroom_path(@first_chatroom), class: "btn btn-success dash-link" %>
+                <div class="p-2"> <%= link_to "My chatrooms", chatroom_path(@first_chatroom), class: "btn btn-success dash-link" %>
               <% else %>
                 <%= "You haven't joined any chatrooms yet!" %>
               <% end %>

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -3,21 +3,21 @@
     <div class="row justify-content-center">
       <div class="col-12">
 
-        <div class="call-to-action d-flex justify-content-center mt-5">
-          <strong>Plan Your Next Adventure - Find an Event Now!</strong>
-        </div>
+      <div class="call-to-action d-flex justify-content-center mt-5">
+        <h1>Plan Your Next Adventure - Find an Event Now!</h1>
+      </div>
 
-        <div class="d-flex justify-content-center mt-5">
-          <div class="search search-form">
-            <%= form_with(url: { action: "search_events" }, method: "get") do |form| %>
+      <div class="d-flex justify-content-center mt-5">
+        <div class="search search-form">
+          <%= form_with(url: { action: "search_events" }, method: "get") do |form| %>
 
-              <div class="search-container">
-                <%= form.text_field :query, placeholder: "Sports in Melbourne...", class: "search-input", autocomplete: "off"%>
-                <div class="search-date-image"><i class="fa-regular fa-calendar"></i></div>
-                <%= form.text_field :date, placeholder: nil, class: "search-date", data: { controller: "datepicker" } %>
-                <div class="search-date-image"><i class="fa-solid fa-magnifying-glass"></i></div>
-                <button type="submit" class="search-button"></button>
-              </div>
+            <div class="search-container">
+              <%= form.text_field :query, placeholder: "Sports in Melbourne...", class: "search-input", autocomplete: "off"%>
+              <div class="search-date-image"><i class="fa-regular fa-calendar"></i></div>
+              <%= form.text_field :date, placeholder: nil, class: "search-date", data: { controller: "datepicker" } %>
+              <div class="search-date-image"><i class="fa-solid fa-magnifying-glass"></i></div>
+              <button type="submit" class="search-button"></button>
+            </div>
 
           <% end %>
         </div>
@@ -38,16 +38,71 @@
                 <div class="card" data-controller="button-logic">
                   <img src=<%= event["thumbnail"] %> alt="Event Image">
                   <div class="card-content">
-                    <div class="card-title" data-button-logic-target="eventName"><%= event["title"] %></div>
-                    <div class="card-address"><%= event["address"].join(", ") %></div>
+
+                    <div class="card-title">
+                      <button type="button" class="btn btn-light" data-button-logic-target="eventName" data-bs-toggle="modal" data-bs-target="#exampleModal-<%= index %>"><%= event["title"] %></button>
+                    </div>
+
+                    <!-- Event Modal -->
+
+                    <div class="modal fade" id="exampleModal-<%= index %>" tabindex="-1" aria-labelledby="exampleModalLabel" aria-hidden="true">
+                      <div class="modal-dialog modal-lg">
+                        <div class="modal-content">
+                          <div class="modal-header">
+                            <h1 class="modal-title fs-5" id="exampleModalLabel"><%= event["title"] %></h1>
+                            <button type="button" class="btn" data-bs-dismiss="modal" aria-label="Close"><i class="fa-solid fa-x" style="color: #000000;"></i></button>
+                          </div>
+                          <div class="modal-body">
+                            <div class="row">
+                              <% if event["thumbnail"].present? %>
+                                <div class="col-sm-12 mb-3">
+                                  <img src=<%= event["thumbnail"] %> alt="Event Image">
+                                </div>
+                              <% else %>
+                                <div class="col-sm-12 mb-3">
+                                  <img src="path_to_default_image" alt="Default Event Image">
+                                </div>
+                              <% end %>
+                            </div>
+                            <div class="row">
+                              <div class="col-sm-12">
+                                <p><b>Date: </b><%= event["date"]["start_date"] if event["date"] %></p>
+                                <p><b>Location: </b><%= event["address"].join(", ") %></p>
+                                <p><%= event["description"] %></p>
+                              </div>
+                            </div>
+                          </div>
+                          <% if event["ticket_info"].present? %>
+                            <div class="modal-footer text-center">
+                              <div class="row align-items-start">
+                                <div class="row">
+                                  <p><b><em>Click on one of the links below to purchase your tickets.</em></b></p>
+                                </div>
+                                <div class="row">
+                                  <% if event["ticket_info"].present? %>
+                                    <% event["ticket_info"].each do |vendor| %>
+                                      <div class="p-2">
+                                        <a class="btn justify-content-center" href="<%= vendor["link"] %>" target="_blank"><%= vendor["source"] %></a>
+                                      </div>
+                                    <% end %>
+                                  <% end %>
+                                </div>
+                              </div>
+                            </div>
+                          <% end %>
+                        </div>
+                      </div>
+                    </div>
+
                     <div class="card-date"><%= event["date"]["start_date"] if event["date"] %></div>
                     <div class="card-description"><%= event["description"] %></div>
                   </div>
-                  <div class="card-actions d-flex justify-content-center" id="event-card-buttons">
+                  <div class="card-actions" id="event-card-buttons">
                     <div  data-button-logic-target="saveButtonForm">
-                      <%= button_to "Save Event", create_from_api_path(event), class: "btn btn-dark", turbo_method: :post, "data-action": "click->button-logic#handleSaveClick" %>
+                      <%= button_to create_from_api_path(event), class: "btn", turbo_method: :post, "data-action": "click->button-logic#handleSaveClick" do %>
+                        <i class="fa-solid fa-bookmark" style="color: #000000;"></i>
+                      <% end %>
                     </div>
-
 
                     <!-- Success Modal -->
                     <div class="modal fade" id="successModal" tabindex="-1" aria-labelledby="successModalLabel" aria-hidden="true">
@@ -60,7 +115,7 @@
                             Event saved successfully!
                           </div>
                           <div class="modal-footer">
-                            <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
+                            <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
                           </div>
                         </div>
                       </div>
@@ -77,13 +132,13 @@
                             Event already tagged!
                           </div>
                           <div class="modal-footer">
-                            <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
+                            <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
                           </div>
                         </div>
                       </div>
                     </div>
 
-                    <button type="button" class="btn btn-dark" data-bs-toggle="modal" data-bs-target="#purchase-<%= index %>">Purchase</button>
+                    <button type="button" class="btn" data-bs-toggle="modal" data-bs-target="#purchase-<%= index %>"><i class="fa-solid fa-cart-shopping" style="color: #000000;"></i></button>
                     <div class="modal fade" id="purchase-<%= index %>" data-bs-backdrop="static" data-bs-keyboard="false" tabindex="-1" aria-labelledby="purchase" aria-hidden="true">
                       <div class="modal-dialog">
                         <div class="modal-content">
@@ -94,13 +149,13 @@
                             <div class="d-flex flex-column align-items-center">
                               <% event["ticket_info"].each do |vendor| %>
                                 <div class="p-2">
-                                  <a class="btn btn-primary" href="<%= vendor["link"] %>" target="_blank"><%= vendor["source"] %></a>
+                                  <a class="btn" href="<%= vendor["link"] %>" target="_blank"><%= vendor["source"] %></a>
                                 </div>
                               <% end %>
                             </div>
                           </div>
                           <div class="modal-footer">
-                            <button type="reset" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
+                            <button type="reset" class="btn-close" data-bs-dismiss="modal"></button>
                           </div>
                         </div>
                       </div>

--- a/app/views/shared/_all_events.html.erb
+++ b/app/views/shared/_all_events.html.erb
@@ -57,7 +57,7 @@
                               <% if event.ticket_purchase.present? %>
                                 <% ticket_purchase_json = JSON.parse(event.ticket_purchase) %>
                                 <% ticket_purchase_json.each do |info| %>
-                                  <div class="p-2"><a class="btn btn-dark" href="<%= info["link"] %>" target="_blank"><%= info["source"] %></a></div>
+                                  <div class="p-2"><a class="btn" href="<%= info["link"] %>" target="_blank"><%= info["source"] %></a></div>
                                 <% end %>
                               <% end %>
                             </div>
@@ -68,26 +68,27 @@
                   </div>
                 </div>
 
-                <div class="card-address"><%= event.address %></div>
                 <div class="card-date"><%= event.start_time.strftime('%a %b %e') %> - <%= event.end_time.strftime('%a %b %e') %></div>
                 <div class="card-description"><%= event.description %></div>
               </div>
-              <div class="card-actions d-flex justify-content-center" id="event-card-buttons">
+              <div class="card-actions" id="event-card-buttons">
                 <div>
                   <% if current_user.present? == false %>
-                    <%= link_to "Login/Sign Up to save", new_user_session_path,class: "btn btn-dark" %>
+                    <%= link_to "Login/Sign Up to continue", new_user_session_path,class: "btn" %>
                   <% end %>
                 </div>
                 <div>
                   <% if current_user.present? %>
                     <% unless current_user.bookmarks.exists?(event_id: event.id) %>
-                      <%= link_to "Bookmark me", event_bookmarks_path(event), data: { turbo_method: :post, turbo_confirm: "Are you interested?" }, class: "btn btn-dark" %>
+                      <%= link_to event_bookmarks_path(event), data: { turbo_method: :post, turbo_confirm: "Are you interested?" }, class: "btn" do %>
+                        <i class="fa-solid fa-bookmark" style="color: #000000;"></i>
+                      <% end %>
                     <% end %>
                   <% end %>
                 </div>
                 <div>
                   <% if current_user.present? %>
-                    <button type="button" class="btn btn-dark" data-bs-toggle="modal" data-bs-target="#purchase<%= event.id %>">Purchase</button>
+                    <button type="button" class="btn" data-bs-toggle="modal" data-bs-target="#purchase<%= event.id %>"><i class="fa-solid fa-cart-shopping" style="color: #000000;"></i></button>
                   <% end %>
                           <!-- Purchase Modal -->
                   <div class="modal fade" id="purchase<%= event.id %>" data-bs-backdrop="static" data-bs-keyboard="false" tabindex="-1" aria-labelledby="purchase" aria-hidden="true">
@@ -101,7 +102,7 @@
                             <% if event.ticket_purchase.present? %>
                               <% ticket_purchase_json = JSON.parse(event.ticket_purchase) %>
                               <% ticket_purchase_json.each do |info| %>
-                                <div class="p-2"><a class="btn btn-dark" href="<%= info["link"] %>" target="_blank"><%= info["source"] %></a></div>
+                                <div class="p-2"><a class="btn" href="<%= info["link"] %>" target="_blank"><%= info["source"] %></a></div>
                               <% end %>
                             <% else %>
                               <p>No ticket purchase information available.</p>
@@ -109,7 +110,7 @@
                           </div>
                         </div>
                         <div class="modal-footer">
-                          <button type="reset" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
+                          <button type="reset" class="btn-close" data-bs-dismiss="modal"></button>
                         </div>
                       </div>
                     </div>
@@ -117,10 +118,12 @@
                 </div>
                 <div>
                   <% if @itinerary.present? %>
-                    <%= link_to "Add", itinerary_itinerary_events_path(@itinerary, event_id: event.id), class: "btn btn-dark", data: { turbo_method: :post } %>
+                    <%= link_to itinerary_itinerary_events_path(@itinerary, event_id: event.id), class: "btn btn-dark", data: { turbo_method: :post } do %>
+                      <i class="fa-solid fa-plus" style="color: #000000;"></i>
+                    <% end %>
                   <% else %>
                     <% if current_user.present? %>
-                      <button type="button" class="btn btn-dark" data-bs-toggle="modal" data-bs-target="#addToItinerary-<%= event.id %>">Add to an itinerary</button>
+                      <button type="button" class="btn" data-bs-toggle="modal" data-bs-target="#addToItinerary-<%= event.id %>"><i class="fa-solid fa-plus" style="color: #000000;"></i></button>
                       <div class="modal fade" id="addToItinerary-<%= event.id %>" data-bs-backdrop="static" data-bs-keyboard="false" tabindex="-1" aria-labelledby="addToItineraryLabel" aria-hidden="true" data-controller="add-to-itinerary">
                         <div class="modal-dialog">
                           <div class="modal-content">
@@ -137,8 +140,8 @@
                                   <% end %>
                                 </select>
                                 <div class="modal-footer">
-                                  <button type="reset" class="btn btn-dark" data-bs-dismiss="modal">Close</button>
-                                  <button type="reset" class="btn btn-dark" data-bs-toggle="modal" data-bs-target="#addToItinerary-<%= event.id %>" id="addToItineraryButton-<%= event.id %>">Add to this itinerary</button>
+                                  <button type="reset" class="btn" data-bs-toggle="modal" data-bs-target="#addToItinerary-<%= event.id %>" id="addToItineraryButton-<%= event.id %>"><i class="fa-solid fa-plus" style="color: #000000;"></i></button>
+                                  <button type="reset" class="btn-close" data-bs-dismiss="modal"></button>
                                 </div>
                               </form>
                             </div>

--- a/app/views/shared/_my_events.html.erb
+++ b/app/views/shared/_my_events.html.erb
@@ -53,7 +53,7 @@
                             <% if bookmark.event.ticket_purchase.present? %>
                               <% ticket_purchase_json = JSON.parse(bookmark.event.ticket_purchase) %>
                               <% ticket_purchase_json.each do |info| %>
-                                <div class="p-2"><a class="btn btn-dark" href="<%= info["link"] %>" target="_blank"><%= info["source"] %></a></div>
+                                <div class="p-2"><a class="btn" href="<%= info["link"] %>" target="_blank"><%= info["source"] %></a></div>
                               <% end %>
                             <% end %>
                           </div>
@@ -69,9 +69,11 @@
             </div>
             <div class="card-actions">
               <% if bookmark.event.chatroom.present? %>
-                <%= link_to "Join the #{bookmark.event.name} channel", chatroom_path(bookmark.event.chatroom.id), class: "btn btn-success" %>
+                <%= link_to chatroom_path(bookmark.event.chatroom.id), class: "btn" do %>
+                  <i class="fa-solid fa-comments" style="color: #000000;"></i>
+                <% end %>
               <% end %>
-              <button type="button" class="btn btn-dark" data-bs-toggle="modal" data-bs-target="#addToItinerary-<%= bookmark.event.id %>">Add to an itinerary</button>
+              <button type="button" class="btn" data-bs-toggle="modal" data-bs-target="#addToItinerary-<%= bookmark.event.id %>"><i class="fa-solid fa-plus" style="color: #000000;"></i></button>
               <div class="modal fade" id="addToItinerary-<%= bookmark.event.id %>" data-bs-backdrop="static" data-bs-keyboard="false" tabindex="-1" aria-labelledby="addToItineraryLabel" aria-hidden="true" data-controller="add-to-itinerary">
                 <div class="modal-dialog">
                   <div class="modal-content">
@@ -88,8 +90,8 @@
                           <% end %>
                         </select>
                         <div class="modal-footer">
-                          <button type="reset" class="btn btn-dark" data-bs-dismiss="modal">Close</button>
-                          <button type="reset" class="btn btn-dark" data-bs-toggle="modal" data-bs-target="#addToItinerary-<%= bookmark.event.id %>" id="addToItineraryButton-<%= bookmark.event.id %>">Add to this itinerary</button>
+                          <button type="reset" class="btn" data-bs-toggle="modal" data-bs-target="#addToItinerary-<%= bookmark.event.id %>" id="addToItineraryButton-<%= bookmark.event.id %>"><i class="fa-solid fa-plus" style="color: #000000;"></i></button>
+                          <button type="reset" class="btn-close" data-bs-dismiss="modal"></button>
                         </div>
                       </form>
                     </div>
@@ -97,7 +99,7 @@
                 </div>
               </div>
               <% if bookmark.event.ticket_purchase.present? %>
-                <button type="button" class="btn btn-dark" data-bs-toggle="modal" data-bs-target="#purchase-<%= index %>">Purchase</button>
+                <button type="button" class="btn" data-bs-toggle="modal" data-bs-target="#purchase-<%= index %>"><i class="fa-solid fa-cart-shopping" style="color: #000000;"></i></button>
                 <div class="modal fade" id="purchase-<%= index %>" data-bs-backdrop="static" data-bs-keyboard="false" tabindex="-1" aria-labelledby="purchase" aria-hidden="true">
                   <div class="modal-dialog">
                     <div class="modal-content">
@@ -108,25 +110,31 @@
                         <div class="d-flex flex-column align-items-center">
                           <% ticket_purchase_json = JSON.parse(bookmark.event.ticket_purchase) %>
                           <% ticket_purchase_json.each do |info| %>
-                            <div class="p-2"><a class="btn btn-dark" href="<%= info["link"] %>" target="_blank"><%= info["source"] %></a></div>
+                            <div class="p-2"><a class="btn" href="<%= info["link"] %>" target="_blank"><%= info["source"] %></a></div>
                           <% end %>
                         </div>
                       </div>
                       <div class="modal-footer">
-                        <button type="reset" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
+                        <button type="reset" class="btn" data-bs-dismiss="modal">Close</button>
                       </div>
                     </div>
                   </div>
                 </div>
               <% end %>
-              <% if bookmark.status == "interested" %>
+              <%
+=begin%>
+ <% if bookmark.status == "interested" %>
                 <%= link_to "I'm going!", bookmark_path(bookmark), class: "btn btn-primary", data: { turbo_method: :patch } %>
               <% elsif bookmark.status == "attending" %>
                 <p>You are going to this event!</p>
               <% elsif bookmark.status == "attended" %>
                 <p>You went to this event!</p>
               <% end %>
-              <%= link_to "Delete bookmark", bookmark_path(bookmark), data: { turbo_method: :delete, turbo_confirm: "Are you sure?" }, class: "btn btn-danger" %>
+<%
+=end%>
+              <%= link_to bookmark_path(bookmark), data: { turbo_method: :delete, turbo_confirm: "Are you sure?" }, class: "btn" do %>
+                <i class="fa-solid fa-x" style="color: #000000;"></i>
+              <% end %>
             </div>
           </div>
         </div>


### PR DESCRIPTION
Event cards are now the same everywhere you see them.
I've also updated the chatroom cards. 
Event will now pop up on all event cards, and chatroom cards when clicking on the event name.
When hovering on the fontawesome icon it will change to text describing what the action is.
Removed the word 'close' from all modals and replaced with the class btn-close to show an x.

<img width="401" alt="EventCardMain" src="https://github.com/berulds/eventseeker/assets/134824154/ca8d94ca-f4f5-46f3-b8b2-f7ab80a8c9dc">
![EventCardMainHover](https://github.com/berulds/eventseeker/assets/134824154/fc13c591-c923-470c-b237-7850126f284a)
<img width="835" alt="ChatroomCards" src="https://github.com/berulds/eventseeker/assets/134824154/e7cca3aa-d19f-45e3-8960-dfa741432603">
![ChatroomCardHover](https://github.com/berulds/eventseeker/assets/134824154/5f9a9649-60a6-4e2e-9c9a-432131710a9e)
